### PR TITLE
FIX: caida del juego con bots

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -11,34 +11,29 @@ from cannonballs import (
 from player import Player
 from tank import Tank
 
-
 class Bot(Tank):
     def __init__(
         self, color: pygame.Color | str, position: pygame.Vector2, player: Player
     ):
         super().__init__(color, position, player)
 
-    def random_shoot(self, position2: pygame.Vector2):
+    def random_shoot(self, position2: pygame.Vector2, gravity):
         option = random.randint(0, 1)
         if option == 0:
             self.selection_cannonball()
             delta_x = position2.x - self.position.x
             delta_y = position2.y - self.position.y
             d = pygame.math.Vector2(delta_x, delta_y).length()
-            print("d: ", d)
             angle = abs(
                 pygame.math.Vector2(delta_x, delta_y).angle_to(
                     pygame.math.Vector2(1, 0)
                 )
             )
             angle = math.radians(angle)
-            print("angle: ", angle)
             if delta_y != 0:
-                velocity = (d * 9.8) / (2 * abs(delta_y))
-                print("velocity: ", velocity)
+                velocity = (d * gravity) / (2 * abs(delta_y))
             else:
                 velocity = 0
-                print("velocity: ", velocity)
             self.shoot_angle = angle
             self.shoot_velocity = velocity
         if option == 1:
@@ -66,12 +61,11 @@ class Bot(Tank):
             if cannon == 1 and self.player.money >= 1000:
                 self.player.money = self.player.money - 1000
                 self.available[0] = self.available[0] + 1
-                print("compré una de 1", self.player.money)
+
             if cannon == 2 and self.player.money >= 2500:
                 self.player.money = self.player.money - 2500
                 self.available[1] = self.available[1] + 1
-                print("compré una de 2", self.player.money)
+
             if cannon == 3 and self.player.money >= 4000:
                 self.player.money = self.player.money - 4000
                 self.available[2] = self.available[2] + 1
-                print("compré una de 3", self.player.money)

--- a/src/bot.py
+++ b/src/bot.py
@@ -11,6 +11,7 @@ from cannonballs import (
 from player import Player
 from tank import Tank
 
+
 class Bot(Tank):
     def __init__(
         self, color: pygame.Color | str, position: pygame.Vector2, player: Player

--- a/src/round.py
+++ b/src/round.py
@@ -144,8 +144,8 @@ class Round:
         find = True
         while find:
             random_tank = random.randint(0, len(self.tanks) - 1)
-            if random_tank != self.actual_player and not self.tanks[random_tank].is_alive:
-                self.get_current_tank().random_shoot(self.tanks[random_tank].position)
+            if random_tank != self.actual_player and self.tanks[random_tank].life > 0:
+                self.get_current_tank().random_shoot(self.tanks[random_tank].position, self.gravity)
                 find = False
 
     def draw_cannonball_indicator(self, sf: pygame.surface.Surface):

--- a/src/round.py
+++ b/src/round.py
@@ -145,7 +145,9 @@ class Round:
         while find:
             random_tank = random.randint(0, len(self.tanks) - 1)
             if random_tank != self.actual_player and self.tanks[random_tank].life > 0:
-                self.get_current_tank().random_shoot(self.tanks[random_tank].position, self.gravity)
+                self.get_current_tank().random_shoot(
+                    self.tanks[random_tank].position, self.gravity
+                )
                 find = False
 
     def draw_cannonball_indicator(self, sf: pygame.surface.Surface):
@@ -536,7 +538,9 @@ class Round:
                     self.has_fallen.add(i)
                 elif i in self.has_fallen:
                     tank.life = max(
-                        0, tank.life - int(self.falling_speed * constants.DAMAGE_PER_SPEED)
+                        0,
+                        tank.life
+                        - int(self.falling_speed * constants.DAMAGE_PER_SPEED),
                     )
                     print(self.falling_speed * constants.DAMAGE_PER_SPEED)
                     tank.position.y = (

--- a/src/shop_menu.py
+++ b/src/shop_menu.py
@@ -86,7 +86,7 @@ class Shop:
             (instance.windows_size[0] / 1.59, instance.windows_size[1] / 4.04),
         )
         self.screen.blit(
-            self.buy_ammo("Buy"),
+            self.buy_ammo("Comprar"),
             (instance.windows_size[0] / 1.67, instance.windows_size[1] / 1.82),
         )
         money = self.principal_font.render(f"${self.money_player}", True, "#ffffff")

--- a/src/tank.py
+++ b/src/tank.py
@@ -206,7 +206,7 @@ class Tank(Drawable, Collidable):
             screen, self.color, (cannon_x, cannon_y), (muzzle_x, muzzle_y), 6
         )
 
-    def random_shoot(self, position):
+    def random_shoot(self, position, gravity):
         pass
 
     def buy_cannonballs(self):


### PR DESCRIPTION
Cambié una condición para que el juego no se caiga al jugar con dos o más bots, ahora el bucle busca tanques con vida mayor a 0, además ahora el bot calcula el disparo considerando la gravedad del contexto